### PR TITLE
Resize window from context menu and application menu

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,10 @@
   },
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "no-console": "error"
+    "no-console": "error",
+    "prefer-const": ["error", {
+        "destructuring": "all"
+    }]
   },
   "overrides": [
     {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -92,3 +92,21 @@ ipcMain.handle("save-temp-file", async (event, content, suffix) => {
   await fs.promises.writeFile(p, content);
   return p;
 });
+
+ipcMain.handle("resize", async (event, ratio: "16:9" | "4:3") => {
+  if (mainWindow === null) {
+    return;
+  }
+  let [width, height] = mainWindow.getSize();
+  switch (ratio) {
+    case "16:9":
+      height = width / (16 / 9);
+      break;
+    case "4:3":
+      height = width / (4 / 3);
+      break;
+    default:
+      throw new Error("unexpected ratio: " + ratio);
+  }
+  mainWindow.setSize(width, height, true);
+});

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,0 +1,58 @@
+import { Menu, shell } from "electron";
+
+interface Props {
+  onResize: (ratio: "4:3" | "16:9") => void;
+}
+
+const createTemplate = (
+  props: Props
+): Array<Electron.MenuItemConstructorOptions> => {
+  return [
+    { role: "appMenu" },
+    {
+      label: "File",
+      submenu: [{ role: "close" }],
+    },
+    {
+      label: "Window",
+      submenu: [
+        { role: "minimize" },
+        { role: "zoom" },
+        {
+          label: "Resize",
+          submenu: [
+            {
+              label: "Standard (4:3)",
+              click: () => props.onResize("4:3"),
+            },
+            {
+              label: "Widescreen (16:9)",
+              click: () => props.onResize("16:9"),
+            },
+          ],
+        },
+        { type: "separator" },
+        { role: "front" },
+      ],
+    },
+    {
+      role: "help",
+      submenu: [
+        {
+          label: "Visit website",
+          click: async () => {
+            await shell.openExternal("https://github.com/ueokande/sanscadre/");
+          },
+        },
+      ],
+    },
+  ];
+};
+
+export const create = (props: Props): Electron.Menu => {
+  if (process.platform === "darwin") {
+    const template = createTemplate(props);
+    return Menu.buildFromTemplate(template);
+  }
+  return new Menu();
+};

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import ResizeHint from "./ResizeHint";
 import TitleBar from "./TitleBar";
 import SidebarKnob from "./SidebarKnob";
 import PDFReader from "./PDFReader";
+import ContextMenu from "./ContextMenu";
 import * as ipc from "./ipc";
 
 const Container = styled.div`
@@ -110,6 +111,7 @@ const App = () => {
   return (
     <AppContext.Provider value={{ state: appState, dispatch: appDispatch }}>
       <UIContext.Provider value={{ state: uiState, dispatch: uiDispatch }}>
+        <ContextMenu />
         <Container
           onMouseEnter={showSidebarKnob}
           onMouseLeave={hideSidebarKnob}

--- a/src/renderer/ContextMenu.tsx
+++ b/src/renderer/ContextMenu.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { remote } from "electron";
+import AppContext from "./AppContext";
+
+const { Menu, MenuItem } = remote;
+
+const ContextMenu = () => {
+  const { state, dispatch } = React.useContext(AppContext);
+  const menu = React.useRef(new Menu());
+
+  React.useEffect(() => {
+    const newMenu = new Menu();
+    newMenu.append(
+      new MenuItem({
+        label: "Next",
+        click: () => dispatch({ type: "NEXT_PAGE" }),
+        enabled:
+          state.pages.length > 0 && state.active !== state.pages.length - 1,
+      })
+    );
+    newMenu.append(
+      new MenuItem({
+        label: "Previous",
+        click: () => dispatch({ type: "PREV_PAGE" }),
+        enabled: state.pages.length > 0 && state.active !== 0,
+      })
+    );
+    menu.current = newMenu;
+  }, [state]);
+
+  const handleContextMenu = React.useCallback((e: Event) => {
+    if (menu.current === undefined) {
+      return;
+    }
+    e.preventDefault();
+    menu.current.popup({ window: remote.getCurrentWindow() });
+  }, []);
+
+  React.useEffect(() => {
+    window.addEventListener("contextmenu", handleContextMenu, false);
+    return () => {
+      window.removeEventListener("contextmenu", handleContextMenu);
+    };
+  }, [window]);
+  return null;
+};
+
+export default ContextMenu;

--- a/src/renderer/ContextMenu.tsx
+++ b/src/renderer/ContextMenu.tsx
@@ -1,31 +1,41 @@
 import React from "react";
 import { remote } from "electron";
 import AppContext from "./AppContext";
+import * as ipc from "./ipc";
 
-const { Menu, MenuItem } = remote;
+const { Menu } = remote;
 
 const ContextMenu = () => {
   const { state, dispatch } = React.useContext(AppContext);
   const menu = React.useRef(new Menu());
 
   React.useEffect(() => {
-    const newMenu = new Menu();
-    newMenu.append(
-      new MenuItem({
+    menu.current = Menu.buildFromTemplate([
+      {
         label: "Next",
         click: () => dispatch({ type: "NEXT_PAGE" }),
         enabled:
           state.pages.length > 0 && state.active !== state.pages.length - 1,
-      })
-    );
-    newMenu.append(
-      new MenuItem({
+      },
+      {
         label: "Previous",
         click: () => dispatch({ type: "PREV_PAGE" }),
         enabled: state.pages.length > 0 && state.active !== 0,
-      })
-    );
-    menu.current = newMenu;
+      },
+      {
+        label: "Resize",
+        submenu: [
+          {
+            label: "Standard (4:3)",
+            click: () => ipc.resize("4:3"),
+          },
+          {
+            label: "Widescreen (16:9)",
+            click: () => ipc.resize("16:9"),
+          },
+        ],
+      },
+    ]);
   }, [state]);
 
   const handleContextMenu = React.useCallback((e: Event) => {

--- a/src/renderer/KeyHandler.tsx
+++ b/src/renderer/KeyHandler.tsx
@@ -7,11 +7,7 @@ interface Props {
 }
 
 const KeyHandler: React.FC<Props> = ({ target }) => {
-  const { state, dispatch } = React.useContext(AppContext);
-  const stateRef = React.useRef(state);
-  React.useEffect(() => {
-    stateRef.current = state;
-  }, [state]);
+  const { dispatch } = React.useContext(AppContext);
 
   React.useEffect(() => {
     target.addEventListener("keydown", (e) => {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -6,3 +6,7 @@ export const saveTempFile = async (
 ): Promise<string> => {
   return await ipcRenderer.invoke("save-temp-file", content, suffix);
 };
+
+export const resize = async (ratio: "16:9" | "4:3"): Promise<void> => {
+  return await ipcRenderer.invoke("resize", ratio);
+};


### PR DESCRIPTION
Support resizing window via context menu and application menu(macOS only).  The menu has two choices: Standard (4:3) and Widescreen (16:9).
![context_menu](https://user-images.githubusercontent.com/534166/89728965-44928e80-da6c-11ea-9c05-56e294f882b8.png)
